### PR TITLE
Remove authorization structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all    :; dapp build
+all    :; dapp --use solc:0.6.11 build
 clean  :; dapp clean
-test   :; dapp test
+test   :; dapp --use solc:0.6.11 test -v
 deploy :; dapp create Lerp

--- a/src/Lerp.sol
+++ b/src/Lerp.sol
@@ -16,12 +16,6 @@ interface FileIlkLike {
 
 abstract contract BaseLerp {
 
-    // --- Auth ---
-    mapping (address => uint256) public wards;
-    function rely(address usr) external auth { wards[usr] = 1; }
-    function deny(address usr) external auth { wards[usr] = 0; }
-    modifier auth { require(wards[msg.sender] == 1); _; }
-
     uint256 constant WAD = 10 ** 18;
 
     address immutable public target;
@@ -30,10 +24,10 @@ abstract contract BaseLerp {
     uint256 immutable public end;
     uint256 immutable public duration;
 
-    bool public started;
-    bool public done;
-    uint256 public startTime;
-    
+    bool              public started;
+    bool              public done;
+    uint256           public startTime;
+
     constructor(address target_, bytes32 what_, uint256 start_, uint256 end_, uint256 duration_) public {
         require(duration_ != 0, "Lerp/no-zero-duration");
         require(duration_ <= 365 days, "Lerp/max-duration-one-year");
@@ -46,22 +40,13 @@ abstract contract BaseLerp {
         start = start_;
         end = end_;
         duration = duration_;
-        started = false;
-        done = false;
-        wards[msg.sender] = 1;
-    }
-
-    function init() external auth {
-        require(!started, "Lerp/already-started");
-        require(!done, "Lerp/finished");
-        update(start);
-        startTime = block.timestamp;
         started = true;
+        startTime = block.timestamp;
+        done = false;
     }
 
     function tick() external {
         require(started, "Lerp/not-started");
-        require(block.timestamp > startTime, "Lerp/no-time-elapsed");
         require(!done, "Lerp/finished");
         if (block.timestamp < startTime + duration) {
             // All bounds are constrained in the constructor so no need for safe-math
@@ -108,5 +93,4 @@ contract IlkLerp is BaseLerp {
     function update(uint256 value) override internal {
         FileIlkLike(target).file(ilk, what, value);
     }
-
 }

--- a/src/Lerp.t.sol
+++ b/src/Lerp.t.sol
@@ -36,7 +36,7 @@ contract TestContract {
 }
 
 contract DssLerpTest is DSTest {
-    
+
     Hevm hevm;
 
     TestContract target;
@@ -61,12 +61,12 @@ contract DssLerpTest is DSTest {
         assertEq(lerp.start(), 1 * TOLL_ONE_PCT);
         assertEq(lerp.end(), 1 * TOLL_ONE_PCT / 10);
         assertEq(lerp.duration(), 9 days);
-        assertTrue(!lerp.started());
+        assertTrue(lerp.started());
         assertTrue(!lerp.done());
         assertEq(lerp.startTime(), 0);
         assertEq(target.value(), 0);
         target.rely(address(lerp));
-        lerp.init();
+        lerp.tick();
         assertTrue(lerp.started());
         assertTrue(!lerp.done());
         assertEq(lerp.startTime(), block.timestamp);
@@ -97,7 +97,6 @@ contract DssLerpTest is DSTest {
 
         Lerp lerp = new Lerp(address(target), "value", start, end, duration);
         target.rely(address(lerp));
-        lerp.init();
         hevm.warp(now + deltaTime);
         lerp.tick();
         uint256 value = target.value();
@@ -114,7 +113,6 @@ contract DssLerpTest is DSTest {
 
         Lerp lerp = new Lerp(address(target), "value", start, end, duration);
         target.rely(address(lerp));
-        lerp.init();
         hevm.warp(now + deltaTime);
         lerp.tick();
         uint256 value = target.value();
@@ -131,7 +129,6 @@ contract DssLerpTest is DSTest {
 
         Lerp lerp = new Lerp(address(target), "value", start, end, duration);
         target.rely(address(lerp));
-        lerp.init();
         hevm.warp(now + deltaTime);
         lerp.tick();
         uint256 value = target.value();
@@ -154,7 +151,6 @@ contract DssLerpTest is DSTest {
 
         Lerp lerp = new Lerp(address(target), "value", start, end, duration);
         target.rely(address(lerp));
-        lerp.init();
         hevm.warp(now + deltaTime);
         lerp.tick();
         uint256 value = target.value();
@@ -171,7 +167,6 @@ contract DssLerpTest is DSTest {
 
         BaseLerp lerp = BaseLerp(factory.newLerp(address(target), "value", start, end, duration));
         target.rely(address(lerp));
-        lerp.init();
         hevm.warp(now + deltaTime);
         lerp.tick();
         uint256 value = target.value();
@@ -188,7 +183,6 @@ contract DssLerpTest is DSTest {
 
         BaseLerp lerp = BaseLerp(factory.newIlkLerp(address(target), "someIlk", "value", start, end, duration));
         target.rely(address(lerp));
-        lerp.init();
         hevm.warp(now + deltaTime);
         lerp.tick();
         uint256 value = target.ilkvalue();

--- a/src/LerpFactory.sol
+++ b/src/LerpFactory.sol
@@ -11,5 +11,4 @@ contract LerpFactory {
     function newIlkLerp(address target_, bytes32 ilk_, bytes32 what_, uint256 start_, uint256 end_, uint256 duration_) external returns (address) {
         return address(new IlkLerp(target_, ilk_, what_, start_, end_, duration_));
     }
-
 }

--- a/src/LerpFactory.sol
+++ b/src/LerpFactory.sol
@@ -5,17 +5,11 @@ import "./Lerp.sol";
 contract LerpFactory {
 
     function newLerp(address target_, bytes32 what_, uint256 start_, uint256 end_, uint256 duration_) external returns (address) {
-        Lerp lerp = new Lerp(target_, what_, start_, end_, duration_);
-        lerp.rely(msg.sender);
-        lerp.deny(address(this));
-        return address(lerp);
+        return address(new Lerp(target_, what_, start_, end_, duration_));
     }
 
     function newIlkLerp(address target_, bytes32 ilk_, bytes32 what_, uint256 start_, uint256 end_, uint256 duration_) external returns (address) {
-        IlkLerp lerp = new IlkLerp(target_, ilk_, what_, start_, end_, duration_);
-        lerp.rely(msg.sender);
-        lerp.deny(address(this));
-        return address(lerp);
+        return address(new IlkLerp(target_, ilk_, what_, start_, end_, duration_));
     }
 
 }


### PR DESCRIPTION
Removes the authorization structure and `init()` function. 

With the lerp-fab, a contract like this can (and probably should) be deployed at the time of casting. This removes the need for maintaining authorizations and the auditing overhead that entails, and allows the calling of `tick()` immediately upon authorization.

Open question whether the initial `tick()` call should be called within the factory method.