### PR TITLE
add wipe function to clear permission

### DIFF
--- a/src/Lerp.sol
+++ b/src/Lerp.sol
@@ -52,11 +52,15 @@ abstract contract BaseLerp {
             //   = end * t + start - start * t [Avoids overflow by moving the subtraction to the end]
             update(end * t / WAD + start - start * t / WAD);
         } else {
-            // Set the end value and de-auth yourself
+            // Set the end value and mark as done
             update(end);
-            DenyLike(target).deny(address(this));
             done = true;
         }
+    }
+
+    function wipe() external {
+        require(done, "Lerp/not-finished");
+        DenyLike(target).deny(address(this));
     }
 
     function update(uint256 value) virtual internal;

--- a/src/Lerp.t.sol
+++ b/src/Lerp.t.sol
@@ -84,6 +84,7 @@ contract DssLerpTest is DSTest {
         lerp.tick();
         assertEq(target.value(), 1 * TOLL_ONE_PCT / 10);    // 0.1%
         assertTrue(lerp.done());
+        lerp.wipe();
         assertEq(target.wards(address(lerp)), 0);
     }
 


### PR DESCRIPTION
Alternative to https://github.com/BellwoodStudios/dss-lerp/pull/2

Adds a `wipe()` function to clear the permission after the lerp is complete. This avoids any potential locking in the tick and allows anyone to clear the permission after the module has completed it's task.

One additional thing that you could do here, which I didn't, would be to set the `startTime` variable to 0 in the wipe, this would add a little extra gas refund to incentivize the caller. I suppose bigger efficiencies could be gained with a full `selfdestruct`, but I wouldn't do it here for auditing reasons.

One more thing I noticed that I didn't put in this PR would be that the `tick()` itself could return the value that's getting sent to `update()`, that way if someone is building this into a keeper or something they will get the value that they're setting. If, say, a debt ceiling were increased they would probably find that value useful for determining how much space they've got to work with.