### PR TITLE
Version Bump and Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all    :; dapp --use solc:0.6.11 build
+all    :; dapp --use solc:0.6.12 build
 clean  :; dapp clean
-test   :; dapp --use solc:0.6.11 test -v
-deploy :; dapp --use solc:0.6.11 build && dapp create LerpFactory
+test   :; dapp --use solc:0.6.12 test -v
+deploy :; make && dapp create LerpFactory

--- a/src/Lerp.sol
+++ b/src/Lerp.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.6.11;
+pragma solidity ^0.6.12;
 
 interface DenyLike {
     function deny(address) external;
@@ -61,6 +61,7 @@ abstract contract BaseLerp {
 
     function tick() external returns (uint256 result) {
         require(!done, "Lerp/finished");
+        require(block.timestamp >= startTime, "Lerp/bad-timestamp");
         if (block.timestamp < startTime + duration) {
             // All bounds are constrained in the constructor so no need for safe-math
             // 0 <= t < WAD

--- a/src/Lerp.sol
+++ b/src/Lerp.sol
@@ -61,18 +61,19 @@ abstract contract BaseLerp {
 
     function tick() external returns (uint256 result) {
         require(!done, "Lerp/finished");
-        require(block.timestamp >= startTime, "Lerp/bad-timestamp");
-        if (block.timestamp < startTime + duration) {
-            // All bounds are constrained in the constructor so no need for safe-math
-            // 0 <= t < WAD
-            uint256 t = (block.timestamp - startTime) * WAD / duration;
-            // y = (end - start) * t + start [Linear Interpolation]
-            //   = end * t + start - start * t [Avoids overflow by moving the subtraction to the end]
-            update(result = end * t / WAD + start - start * t / WAD);
-        } else {
-            // Set the end value and mark as done
-            update(result = end);
-            done = true;
+        if (block.timestamp >= startTime) {
+            if (block.timestamp < startTime + duration) {
+                // All bounds are constrained in the constructor so no need for safe-math
+                // 0 <= t < WAD
+                uint256 t = (block.timestamp - startTime) * WAD / duration;
+                // y = (end - start) * t + start [Linear Interpolation]
+                //   = end * t + start - start * t [Avoids overflow by moving the subtraction to the end]
+                update(result = end * t / WAD + start - start * t / WAD);
+            } else {
+                // Set the end value and mark as done
+                update(result = end);
+                done = true;
+            }
         }
     }
 

--- a/src/Lerp.t.sol
+++ b/src/Lerp.t.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.11;
+pragma solidity ^0.6.12;
 
 import "ds-test/test.sol";
 

--- a/src/LerpFactory.sol
+++ b/src/LerpFactory.sol
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity ^0.6.11;
+pragma solidity ^0.6.12;
 
 import "./Lerp.sol";
 


### PR DESCRIPTION
 * Bumped to 0.6.12 to match the rest of the code base
 * Added an additional check to be extra safe in the case timestamps are not always increasing