### PR TITLE
Add test of duplicate bug state

### DIFF
--- a/src/Lerp.t.sol
+++ b/src/Lerp.t.sol
@@ -333,9 +333,9 @@ contract DssLerpTest is DSTest {
         uint256 deltaTime = 3;
 
         bytes32 nameTag = "MYLERP";
-        BaseLerp lerp = BaseLerp(factory.newLerp(nameTag, address(target), "value", block.timestamp, start, end, duration));
+        BaseLerp lerp1 = BaseLerp(factory.newLerp(nameTag, address(target), "value", block.timestamp, start, end, duration));
 
-        assertEq(factory.lerps(nameTag), address(lerp));
+        assertEq(factory.lerps(nameTag), address(lerp1));
         assertEq(factory.count(), 1);
 
 
@@ -348,23 +348,37 @@ contract DssLerpTest is DSTest {
         assertEq(factory.lerps(nameTag), address(lerp2));
         assertEq(factory.count(), 2);
 
-        assertEq(factory.active(0), address(lerp));
+        assertEq(factory.active(0), address(lerp1));
         assertEq(factory.active(1), address(lerp2));
 
         address[2] memory addresses;
-        addresses[0] = address(lerp);
+        addresses[0] = address(lerp1);
         addresses[1] = address(lerp2);
         address[] memory raddresses = factory.list();
         assertEq(raddresses[0], addresses[0]);
         assertEq(raddresses[1], addresses[1]);
-        target.rely(address(lerp));
+        target.rely(address(lerp1));
         target.rely(address(lerp2));
         hevm.warp(now + deltaTime);
 
         factory.tall(); // Both Lerps get called on the same target, but only one lerp is in the mapping.
 
-        assertTrue(!lerp.done());
+        assertTrue(!lerp1.done());
         assertTrue(!lerp2.done()); // Both Lerps are still active, no way to remove the first one from the array
+
+        BaseLerp lerp3 = BaseLerp(factory.newLerp(nameTag, address(target), "value", block.timestamp, start, end, duration));
+
+        target.deny(address(lerp1));
+        target.rely(address(lerp3));
+
+        factory.tall(); // Three Lerps get called, lerp 1 is replaced with lerp 3
+
+        addresses[0] = address(lerp3);
+        addresses[1] = address(lerp2);
+        raddresses = factory.list();
+        assertEq(raddresses[0], addresses[0]);
+        assertEq(raddresses[1], addresses[1]); // lerp3 is called first, then lerp 1 in tall
+
     }
 
 }

--- a/src/Lerp.t.sol
+++ b/src/Lerp.t.sol
@@ -326,7 +326,7 @@ contract DssLerpTest is DSTest {
         assertEq(badDenyTarget.wards(address(lerp2)), 1);
     }
 
-    function test_lerp_duplicates() public {
+    function testFail_lerp_duplicates() public {
         uint256 start = 10 ** 59;
         uint256 end = 20;
         uint256 duration = 40;
@@ -334,51 +334,8 @@ contract DssLerpTest is DSTest {
 
         bytes32 nameTag = "MYLERP";
         BaseLerp lerp1 = BaseLerp(factory.newLerp(nameTag, address(target), "value", block.timestamp, start, end, duration));
-
-        assertEq(factory.lerps(nameTag), address(lerp1));
-        assertEq(factory.count(), 1);
-
-
-        start = 10 ** 39;
-        end = 10;
-        duration = 40;
-        deltaTime = 3;
+        //                        FAIL HERE
         BaseLerp lerp2 = BaseLerp(factory.newLerp(nameTag, address(target), "value", block.timestamp, start, end, duration));
-
-        assertEq(factory.lerps(nameTag), address(lerp2));
-        assertEq(factory.count(), 2);
-
-        assertEq(factory.active(0), address(lerp1));
-        assertEq(factory.active(1), address(lerp2));
-
-        address[2] memory addresses;
-        addresses[0] = address(lerp1);
-        addresses[1] = address(lerp2);
-        address[] memory raddresses = factory.list();
-        assertEq(raddresses[0], addresses[0]);
-        assertEq(raddresses[1], addresses[1]);
-        target.rely(address(lerp1));
-        target.rely(address(lerp2));
-        hevm.warp(now + deltaTime);
-
-        factory.tall(); // Both Lerps get called on the same target, but only one lerp is in the mapping.
-
-        assertTrue(!lerp1.done());
-        assertTrue(!lerp2.done()); // Both Lerps are still active, no way to remove the first one from the array
-
-        BaseLerp lerp3 = BaseLerp(factory.newLerp(nameTag, address(target), "value", block.timestamp, start, end, duration));
-
-        target.deny(address(lerp1));
-        target.rely(address(lerp3));
-
-        factory.tall(); // Three Lerps get called, lerp 1 is replaced with lerp 3
-
-        addresses[0] = address(lerp3);
-        addresses[1] = address(lerp2);
-        raddresses = factory.list();
-        assertEq(raddresses[0], addresses[0]);
-        assertEq(raddresses[1], addresses[1]); // lerp3 is called first, then lerp 1 in tall
-
     }
 
 }

--- a/src/Lerp.t.sol
+++ b/src/Lerp.t.sol
@@ -326,4 +326,45 @@ contract DssLerpTest is DSTest {
         assertEq(badDenyTarget.wards(address(lerp2)), 1);
     }
 
+    function test_lerp_duplicates() public {
+        uint256 start = 10 ** 59;
+        uint256 end = 20;
+        uint256 duration = 40;
+        uint256 deltaTime = 3;
+
+        bytes32 nameTag = "MYLERP";
+        BaseLerp lerp = BaseLerp(factory.newLerp(nameTag, address(target), "value", block.timestamp, start, end, duration));
+
+        assertEq(factory.lerps(nameTag), address(lerp));
+        assertEq(factory.count(), 1);
+
+
+        start = 10 ** 39;
+        end = 10;
+        duration = 40;
+        deltaTime = 3;
+        BaseLerp lerp2 = BaseLerp(factory.newLerp(nameTag, address(target), "value", block.timestamp, start, end, duration));
+
+        assertEq(factory.lerps(nameTag), address(lerp2));
+        assertEq(factory.count(), 2);
+
+        assertEq(factory.active(0), address(lerp));
+        assertEq(factory.active(1), address(lerp2));
+
+        address[2] memory addresses;
+        addresses[0] = address(lerp);
+        addresses[1] = address(lerp2);
+        address[] memory raddresses = factory.list();
+        assertEq(raddresses[0], addresses[0]);
+        assertEq(raddresses[1], addresses[1]);
+        target.rely(address(lerp));
+        target.rely(address(lerp2));
+        hevm.warp(now + deltaTime);
+
+        factory.tall(); // Both Lerps get called on the same target, but only one lerp is in the mapping.
+
+        assertTrue(!lerp.done());
+        assertTrue(!lerp2.done()); // Both Lerps are still active, no way to remove the first one from the array
+    }
+
 }

--- a/src/LerpFactory.sol
+++ b/src/LerpFactory.sol
@@ -44,6 +44,7 @@ contract LerpFactory {
     }
 
     function newLerp(bytes32 name_, address target_, bytes32 what_, uint256 startTime_, uint256 start_, uint256 end_, uint256 duration_) external auth returns (address lerp) {
+        require(lerps[name_] == address(0));
         lerp = address(new Lerp(target_, what_, startTime_, start_, end_, duration_));
         lerps[name_] = lerp;
         active.push(lerp);
@@ -52,6 +53,7 @@ contract LerpFactory {
     }
 
     function newIlkLerp(bytes32 name_, address target_, bytes32 ilk_, bytes32 what_, uint256 startTime_, uint256 start_, uint256 end_, uint256 duration_) external auth returns (address lerp) {
+        require(lerps[name_] == address(0));
         lerp = address(new IlkLerp(target_, ilk_, what_, startTime_, start_, end_, duration_));
         lerps[name_] = lerp;
         active.push(lerp);

--- a/src/LerpFactory.sol
+++ b/src/LerpFactory.sol
@@ -47,7 +47,7 @@ contract LerpFactory {
         lerp = address(new Lerp(target_, what_, startTime_, start_, end_, duration_));
         lerps[name_] = lerp;
         active.push(lerp);
-        
+
         emit NewLerp(name_, target_, what_, startTime_, start_, end_, duration_);
     }
 
@@ -55,7 +55,7 @@ contract LerpFactory {
         lerp = address(new IlkLerp(target_, ilk_, what_, startTime_, start_, end_, duration_));
         lerps[name_] = lerp;
         active.push(lerp);
-        
+
         emit NewIlkLerp(name_, target_, ilk_, what_, startTime_, start_, end_, duration_);
     }
 
@@ -65,7 +65,7 @@ contract LerpFactory {
             active[index] = active[active.length - 1];
         }
         active.pop();
-        
+
         emit LerpFinished(lerp);
     }
 


### PR DESCRIPTION
Adds a passing test of what I believe to be a bug state.

The factory provides no checking of duplicate tags, so multiple lerps can be added using the same tag. This can be a problem if a lerp containing a generic tag (i.e. `"SURPLUS_BUFFER_LERP"`) is added via the factory. In this case, the tag will only point to the most recent addition but both lerps are still active and called in the `tall` iteration, which could have interesting effects on the system. Since the array itself isn't guaranteed to keep it's ordering, we also can't be assured that the loop will continue to be called in the same order, which is demonstrated when a third lerp is added to the array.

There is no direct way for the auth'ed user to remove a managed lerp from this array but if we are going to track them with labels they probably shouldn't be allowed to overlap.

A couple of ways to potentially fix this might be to:

1) Cheap:  Add a `require(lerps[name_] == address(0));` above the creation of a new lerp via the factory, preventing any duplication. This would require all tags be unique but maybe worth it for auditing historical deployments.
or
2) More expensive, maybe not worth it: track lerp tags and addresses with a struct and parallel array and overwrite the address in the array if a lerp tag already exists, rather than adding it.
or
3) alternatively, remove the labeling overhead altogether and stick with just tracking addresses